### PR TITLE
Incorrect MinMax.toString() output

### DIFF
--- a/org.jenetics/src/main/java/org/jenetics/stat/MinMax.java
+++ b/org.jenetics/src/main/java/org/jenetics/stat/MinMax.java
@@ -156,7 +156,7 @@ public final class MinMax<C> implements Consumer<C> {
 
 	@Override
 	public String toString() {
-		return format("MinMax[count=%d, min=%s, max:%s]", _count, _max, _max);
+		return format("MinMax[count=%d, min=%s, max:%s]", _count, _min, _max);
 	}
 
 	/* *************************************************************************


### PR DESCRIPTION
Fixed incorrect MinMax.toString() output